### PR TITLE
Implement scroll-triggered cascade loading for below-the-fold sections

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,10 +1,12 @@
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense, lazy, useState, useEffect, useRef, useCallback } from 'react';
 import { LanguageProvider } from '../contexts/LanguageContext';
 import Navbar from './Navbar';
 import Hero from './Hero';
 
-// Lazy load all below-the-fold components to reduce initial bundle size
-const Services = lazy(() => import('./Services'));
+// Eagerly loaded with initial bundle (above-the-fold)
+import Services from './Services';
+
+// Lazy load below-the-fold sections — chunks only load when triggered by scroll cascade
 const TechStack = lazy(() => import('./TechStack'));
 const ImpactDashboard = lazy(() => import('./ImpactDashboard'));
 const ProjectsGrid = lazy(() => import('./ProjectsGrid'));
@@ -21,38 +23,121 @@ const LoadingFallback: React.FC = () => (
   </div>
 );
 
+/**
+ * Wrapper that defers rendering until `shouldLoad` is true,
+ * then observes its own visibility to trigger the next section.
+ */
+const LazySection: React.FC<{
+  shouldLoad: boolean;
+  onVisible: () => void;
+  fallback?: React.ReactNode;
+  children: React.ReactNode;
+}> = ({ shouldLoad, onVisible, fallback, children }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const triggered = useRef(false);
+  const onVisibleRef = useRef(onVisible);
+  onVisibleRef.current = onVisible;
+
+  useEffect(() => {
+    if (!shouldLoad || triggered.current) return;
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !triggered.current) {
+          triggered.current = true;
+          onVisibleRef.current();
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '300px 0px' },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [shouldLoad]);
+
+  if (!shouldLoad) return null;
+
+  return (
+    <div ref={ref}>
+      <Suspense fallback={fallback ?? <LoadingFallback />}>
+        {children}
+      </Suspense>
+    </div>
+  );
+};
+
 const App: React.FC = () => {
+  // Tracks how many lazy sections are unlocked.
+  // 0 = only Hero + Services visible
+  // 1 = TechStack, 2 = ImpactDashboard, … 7 = Footer + CookieConsent
+  const [unlockedCount, setUnlockedCount] = useState(0);
+  const servicesRef = useRef<HTMLDivElement>(null);
+
+  const unlock = useCallback((next: number) => {
+    setUnlockedCount((prev) => Math.max(prev, next));
+  }, []);
+
+  // Observe Services section — when it enters viewport, unlock TechStack
+  useEffect(() => {
+    const el = servicesRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          unlock(1);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '300px 0px' },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [unlock]);
+
   return (
     <LanguageProvider>
       <div className="relative">
         <Navbar />
         <main>
           <Hero />
-          <Suspense fallback={<LoadingFallback />}>
+          <div ref={servicesRef}>
             <Services />
-          </Suspense>
-          <Suspense fallback={<LoadingFallback />}>
+          </div>
+
+          <LazySection shouldLoad={unlockedCount >= 1} onVisible={() => unlock(2)}>
             <TechStack />
-          </Suspense>
-          <Suspense fallback={<LoadingFallback />}>
+          </LazySection>
+
+          <LazySection shouldLoad={unlockedCount >= 2} onVisible={() => unlock(3)}>
             <ImpactDashboard />
-          </Suspense>
-          <Suspense fallback={<LoadingFallback />}>
+          </LazySection>
+
+          <LazySection shouldLoad={unlockedCount >= 3} onVisible={() => unlock(4)}>
             <ProjectsGrid />
-          </Suspense>
-          <Suspense fallback={<LoadingFallback />}>
+          </LazySection>
+
+          <LazySection shouldLoad={unlockedCount >= 4} onVisible={() => unlock(5)}>
             <About />
-          </Suspense>
-          <Suspense fallback={<LoadingFallback />}>
+          </LazySection>
+
+          <LazySection shouldLoad={unlockedCount >= 5} onVisible={() => unlock(6)}>
             <ExperienceList />
-          </Suspense>
-          <Suspense fallback={<LoadingFallback />}>
+          </LazySection>
+
+          <LazySection shouldLoad={unlockedCount >= 6} onVisible={() => unlock(7)}>
             <Contact />
-          </Suspense>
+          </LazySection>
         </main>
-        <Suspense fallback={null}>
+
+        <LazySection shouldLoad={unlockedCount >= 7} onVisible={() => {}} fallback={null}>
           <Footer />
-        </Suspense>
+        </LazySection>
+
         <Suspense fallback={null}>
           <CookieConsent />
         </Suspense>


### PR DESCRIPTION
## Summary
This PR implements a progressive, scroll-triggered loading strategy for below-the-fold components. Instead of lazy-loading all sections independently, components now load in a cascading sequence as the user scrolls, reducing initial bundle size while improving perceived performance through strategic preloading.

## Key Changes
- **Services component**: Changed from lazy-loaded to eagerly imported (above-the-fold optimization)
- **LazySection wrapper component**: New reusable component that defers rendering until `shouldLoad` is true, then observes visibility with a 300px rootMargin to trigger the next section in the cascade
- **Scroll cascade system**: Implemented state-based unlock mechanism (`unlockedCount`) that gates component rendering:
  - Level 0: Hero + Services visible
  - Level 1: TechStack unlocked when Services enters viewport
  - Levels 2-7: Subsequent sections unlock progressively as user scrolls
- **Services observer**: Added IntersectionObserver on Services section to trigger TechStack loading when Services becomes visible
- **Consistent loading fallbacks**: All lazy sections use `LoadingFallback` component with configurable fallback prop

## Implementation Details
- Uses `useRef` to track observer state and prevent duplicate triggers
- Implements `useCallback` for stable `unlock` function reference
- 300px rootMargin provides early preloading before sections enter viewport
- Each LazySection only renders its children if `shouldLoad` is true, preventing unnecessary DOM nodes
- Maintains Suspense boundaries for each lazy-loaded component
- Footer and CookieConsent remain on independent loading paths (Footer uses cascade, CookieConsent uses standard Suspense)

https://claude.ai/code/session_015Woefr5LFoeohCAm251KgH